### PR TITLE
Feil parametre i Blogg.search() metoden

### DIFF
--- a/programmering/jplab11/JP11.md
+++ b/programmering/jplab11/JP11.md
@@ -187,7 +187,7 @@ En metode `public boolean slett(Innlegg innlegg)` som sletter innlegget `innlegg
 
 ##### m) - valgfri
 
-En metode `public int[] search(String user, String ord)` som returnere en tabell av id'er på alle innlegg i bloggen der teksten inneholder strengen angitt med parameteren `ord`.
+En metode `public int[] search(String keyword)` som returnere en tabell av id'er på alle innlegg i bloggen der teksten inneholder strengen angitt med parameteren `keyword`.
 
 ## Oppgave 4: Skrive blogg til fil
 


### PR DESCRIPTION
Blogg.search skal være definert som ``public int[] search(String keyword)``.